### PR TITLE
Add IHCSReader interface to provide plate IDs

### DIFF
--- a/components/formats-api/src/loci/formats/IHCSReader.java
+++ b/components/formats-api/src/loci/formats/IHCSReader.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * BSD implementations of Bio-Formats readers and writers
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package loci.formats;
+
+import java.io.IOException;
+import loci.formats.FormatException;
+
+/**
+ * Interface for readers with extended high content screening features.
+ */
+public interface IHCSReader extends IFormatReader {
+
+  /**
+   * Return the identifier for the current plate.
+   */
+  String getPlateIdentifier() throws FormatException, IOException;
+
+}

--- a/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
@@ -40,6 +40,7 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IHCSReader;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 import loci.formats.tiff.IFD;
@@ -64,7 +65,7 @@ import org.xml.sax.Attributes;
  *
  * @author Melissa Linkert melissa at glencoesoftware.com
  */
-public class HarmonyReader extends FormatReader {
+public class HarmonyReader extends FormatReader implements IHCSReader {
 
   // -- Constants --
 

--- a/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
@@ -77,6 +77,7 @@ public class HarmonyReader extends FormatReader {
   private Plane[][] planes;
   private MinimalTiffReader reader;
   private ArrayList<String> metadataFiles = new ArrayList<String>();
+  private String plateID;
 
   // -- Constructor --
 
@@ -88,6 +89,14 @@ public class HarmonyReader extends FormatReader {
     hasCompanionFiles = true;
     datasetDescription =
       "Directory with XML file and one .tif/.tiff file per plane";
+  }
+
+  // -- IHCSReader API methods --
+
+  /* @see loci.formats.IFormatReader#getPlateIdentifier() */
+  public String getPlateIdentifier() throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+    return plateID;
   }
 
   // -- IFormatReader API methods --
@@ -204,6 +213,7 @@ public class HarmonyReader extends FormatReader {
       reader = null;
       planes = null;
       metadataFiles.clear();
+      plateID = null;
     }
   }
 
@@ -398,6 +408,8 @@ public class HarmonyReader extends FormatReader {
       addGlobalMeta(key, xmlMetadata.get(key));
     }
 
+    plateID = handler.getPlateIdentifier();
+
     // populate the MetadataStore
 
     LOGGER.info("Populating OME metadata");
@@ -453,7 +465,7 @@ public class HarmonyReader extends FormatReader {
     if (getMetadataOptions().getMetadataLevel() != MetadataLevel.MINIMUM) {
       store.setPlateName(handler.getPlateName(), 0);
       store.setPlateDescription(handler.getPlateDescription(), 0);
-      store.setPlateExternalIdentifier(handler.getPlateIdentifier(), 0);
+      store.setPlateExternalIdentifier(plateID, 0);
 
       String experimenterID = MetadataTools.createLSID("Experimenter", 0);
       store.setExperimenterID(experimenterID, 0);


### PR DESCRIPTION
Contains commits from https://github.com/glencoesoftware/bioformats/pull/1; will need to be rebased once that is merged.

This adds a new interface (`IHCSReader`) which provides HCS-specific features.  At the moment, only one method (`getPlateIdentifier()`) is defined which returns an identifier for the current plate.

`HarmonyReader` has been updated to implement this interface, and returns the same value for `getPlateIdentifier()` as is set in `MetadataStore.setPlateExternalIdentifier(...)`.

This is used in the initial proposal for plate acquisition grouping in OMERO, currently in https://github.com/melissalinkert/openmicroscopy/commits/grouped-plate-acqs (commits 56a8486 and b1ced39, PR forthcoming once a public fork is in place).
