### PR TITLE
Fix handling of URLs in Harmony datasets

### DIFF
--- a/components/formats-common/src/loci/common/StreamHandle.java
+++ b/components/formats-common/src/loci/common/StreamHandle.java
@@ -156,8 +156,10 @@ public abstract class StreamHandle implements IRandomAccess {
     fp = pos;
 
     if (diff < 0) {
+      // resetStream sets the fp to 0
       resetStream();
-      diff = fp;
+      diff = pos;
+      fp = pos;
     }
     int skipped = stream.skipBytes((int) diff);
     while (skipped < diff) {
@@ -165,6 +167,7 @@ public abstract class StreamHandle implements IRandomAccess {
       if (n == 0) break;
       skipped += n;
     }
+    markManager();
   }
 
   /* @see IRandomAccess.write(ByteBuffer) */

--- a/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
@@ -234,9 +234,13 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
         if (reader == null) {
           reader = new MinimalTiffReader();
         }
-        reader.setId(p.filename);
-        reader.openBytes(0, buf, x, y, w, h);
-        reader.close();
+        try {
+          reader.setId(p.filename);
+          reader.openBytes(0, buf, x, y, w, h);
+        }
+        finally {
+          reader.close();
+        }
       }
       else {
         LOGGER.debug("Could not find file {}", p.filename);
@@ -662,9 +666,14 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
       }
       else if (activePlane != null && "Image".equals(parentName)) {
         if ("URL".equals(currentName)) {
-          Location parent =
-            new Location(currentId).getAbsoluteFile().getParentFile();
-          activePlane.filename = new Location(parent, value).getAbsolutePath();
+          if (value.startsWith("http")) {
+            activePlane.filename = value;
+          }
+          else {
+            Location parent =
+              new Location(currentId).getAbsoluteFile().getParentFile();
+            activePlane.filename = new Location(parent, value).getAbsolutePath();
+          }
         }
         else if ("Row".equals(currentName)) {
           activePlane.row = Integer.parseInt(value) - 1;


### PR DESCRIPTION
Resolves the issue reported in https://github.com/glencoesoftware/bioformats/issues/3.

Without this change, `showinf Oris-Pro_100914__2010-09-14T17_11_35-Measurement1/Images/Index.ref.xml` (or opening in ImageJ) should result in the exception shown in the original issue.  With this change, the same test should result in correct images being displayed.  Images can be compared for correctness either by opening the local TIFF files individually (selecting the `.tiff` instead of `Index.ref.xml` in showinf/ImageJ), or editing `Index.ref.xml` to point to the file paths on disk.
