### PR TITLE
Harmony: fixes for variable field counts between wells

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
@@ -180,7 +180,9 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
     if (!noPixels) {
       for (Plane[] well : planes) {
         for (Plane p : well) {
-          files.add(p.filename);
+          if (p != null && p.filename != null) {
+            files.add(p.filename);
+          }
         }
       }
     }
@@ -227,14 +229,18 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
   {
     FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
 
-    if (getSeries() < planes.length && no < planes[getSeries()].length) {
-      Plane p = planes[getSeries()][no];
+    int seriesIndex = lookupSeriesIndex(getSeries());
+    LOGGER.trace("series = {}, seriesIndex = {}", getSeries(), seriesIndex);
+
+    if (seriesIndex < planes.length && no < planes[seriesIndex].length) {
+      Plane p = planes[seriesIndex][no];
 
       if (new Location(p.filename).exists()) {
         if (reader == null) {
           reader = new MinimalTiffReader();
         }
         try {
+          LOGGER.debug("reading series = {}, no = {} from {}", getSeries(), no, p.filename);
           reader.setId(p.filename);
           reader.openBytes(0, buf, x, y, w, h);
         }
@@ -440,12 +446,20 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
     for (int row=0; row<rows.length; row++) {
       for (int col=0; col<cols.length; col++) {
         int well = row * cols.length + col;
+        LOGGER.debug("Populating well row = {}, col = {}, well = {}", row, col, well);
         store.setWellID(MetadataTools.createLSID("Well", 0, well), 0, well);
         store.setWellRow(new NonNegativeInteger(rows[row]), 0, well);
         store.setWellColumn(new NonNegativeInteger(cols[col]), 0, well);
 
         for (int field=0; field<fields.length; field++) {
           int planesIndex = well * fields.length + field;
+          LOGGER.debug("Populating field = {}, index = {}", field, planesIndex);
+
+          if (planes[planesIndex][0] == null) {
+            // variable number of fields; the field was not acquired in this well
+            continue;
+          }
+
           int imageIndex = planes[planesIndex][0].image;
           if (imageIndex == -1) {
             continue;
@@ -477,6 +491,9 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
       store.setExperimenterLastName(handler.getExperimenterName(), 0);
 
       for (int i=0; i<getSeriesCount(); i++) {
+        if (planes[i][0] == null) {
+          continue;
+        }
         store.setImageExperimenterRef(experimenterID, i);
         if (planes[i][0].acqTime != null) {
           store.setImageAcquisitionDate(new Timestamp(planes[i][0].acqTime), i);
@@ -516,6 +533,20 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
       }
 
     }
+  }
+
+  private int lookupSeriesIndex(int seriesIndex) {
+    int index = 0;
+    for (int i=0; i<planes.length; i++) {
+      if (planes[i][0] == null) {
+        continue;
+      }
+      if (index == seriesIndex) {
+        return i;
+      }
+      index++;
+    }
+    return -1;
   }
 
   // -- Helper classes --


### PR DESCRIPTION
This cleans up support for variable fields so that the `PrecScan Rescan varying number of fields` dataset will open correctly.  Without this change, initializing `Index.idx.xml` will result in a `NullPointerException`; with this change, `showinf` or ImageJ should show 50 series and the generated OME-XML should match up with the row, column, and field indexes in the TIFF file names.
