### PR TITLE
Add support for Columbus datasets

### DIFF
--- a/components/formats-api/src/loci/formats/readers.txt
+++ b/components/formats-api/src/loci/formats/readers.txt
@@ -112,6 +112,7 @@ loci.formats.in.HarmonyReader         # xml, tif, tiff
 loci.formats.in.OperettaReader        # xml, tif, tiff
 loci.formats.in.InveonReader          # hdr, ct.img, cat, ...
 loci.formats.in.CellVoyagerReader     # xml, tif
+loci.formats.in.ColumbusReader        # xml, tif
 
 # standard PIC reader must go last (it accepts any PIC)
 loci.formats.in.BioRadReader          # pic

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -322,14 +322,19 @@ public class ColumbusReader extends FormatReader {
     Timestamp date = new Timestamp(acquisitionDate);
     long timestampSeconds = date.asInstant().getMillis() / 1000;
     int nextWellSample = 0;
+
+    int prevRow = -1, prevCol = -1;
     for (int plane=0; plane<planes.size(); plane++) {
       Plane p = planes.get(plane);
 
-      if (plane % (getImageCount() * nFields) == 0) {
+      if (p.row != prevRow || p.col != prevCol) {
         nextWell++;
         store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
         store.setWellRow(new NonNegativeInteger(p.row), 0, nextWell);
         store.setWellColumn(new NonNegativeInteger(p.col), 0, nextWell);
+
+        prevRow = p.row;
+        prevCol = p.col;
       }
 
       if (plane % getImageCount() == 0) {
@@ -340,7 +345,7 @@ public class ColumbusReader extends FormatReader {
           nextWellSample++;
         }
 
-        if (nextWellSample == nFields) {
+        if (nextWellSample == nFields - 1) {
           nextWellSample = 0;
         }
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -402,10 +402,14 @@ public class ColumbusReader extends FormatReader {
               if (p != null) {
                 p.series = wellSample;
                 store.setChannelName(p.channelName, p.series, p.channel);
-                store.setChannelEmissionWavelength(
-                  new PositiveInteger((int) p.emWavelength), p.series, p.channel);
-                store.setChannelExcitationWavelength(
-                  new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+                if ((int) p.emWavelength > 0) {
+                  store.setChannelEmissionWavelength(
+                    new PositiveInteger((int) p.emWavelength), p.series, p.channel);
+                }
+                if ((int) p.exWavelength > 0) {
+                  store.setChannelExcitationWavelength(
+                    new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+                }
                 store.setChannelColor(p.channelColor, p.series, p.channel);
               }
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -232,7 +232,7 @@ public class ColumbusReader extends FormatReader {
     for (int i=0; i<metadataFiles.size(); i++) {
       String path = new Location(parent + File.separator + metadataFiles.get(i)).getAbsolutePath();
       metadataFiles.set(i, path);
-      if (checkSuffix(path, "xml")) {
+      if (checkSuffix(path, "ColumbusIDX.xml")) {
         parseImageXML(path);
       }
     }
@@ -416,12 +416,24 @@ public class ColumbusReader extends FormatReader {
     }
 
     NodeList plates = root.getElementsByTagName("Plates");
+    if (plates == null) {
+      return;
+    }
     plates = ((Element) plates.item(0)).getElementsByTagName("Plate");
+    if (plates == null) {
+      return;
+    }
     NodeList timestamps = ((Element) plates.item(0)).getElementsByTagName("MeasurementStartTime");
     acquisitionDate = ((Element) timestamps.item(0)).getTextContent();
 
     NodeList images = root.getElementsByTagName("Images");
+    if (images == null) {
+      return;
+    }
     images = ((Element) images.item(0)).getElementsByTagName("Image");
+    if (images == null) {
+      return;
+    }
 
     for (int i=0; i<images.getLength(); i++) {
       Element image = (Element) images.item(i);

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -259,10 +259,19 @@ public class ColumbusReader extends FormatReader {
       int end = metadataFile.indexOf(File.separator);
       String timepointPath =
         end < 0 ? "" : parent + File.separator + metadataFile.substring(0, end);
-      String path = new Location(parent + File.separator + metadataFile).getAbsolutePath();
+      Location f = new Location(parent + File.separator + metadataFile);
+      if (!f.exists()) {
+        metadataFile = metadataFile.substring(end + 1);
+        f = new Location(parent, metadataFile);
+      }
+      String path = f.getAbsolutePath();
       metadataFiles.set(i, path);
       if (checkSuffix(path, "columbusidx.xml")) {
-        parseImageXML(path, timepointDirs.indexOf(timepointPath));
+        int timepoint = timepointDirs.indexOf(timepointPath);
+        if (timepointDirs.size() == 0) {
+          timepoint = 0;
+        }
+        parseImageXML(path, timepoint);
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -43,6 +43,7 @@ import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
 import loci.formats.FormatReader;
 import loci.formats.FormatTools;
+import loci.formats.IHCSReader;
 import loci.formats.MetadataTools;
 import loci.formats.meta.MetadataStore;
 
@@ -68,7 +69,7 @@ import org.w3c.dom.NodeList;
  *
  * @author Melissa Linkert melissa at glencoesoftware.com
  */
-public class ColumbusReader extends FormatReader {
+public class ColumbusReader extends FormatReader implements IHCSReader {
 
   // -- Constants --
 
@@ -94,6 +95,14 @@ public class ColumbusReader extends FormatReader {
     suffixSufficient = false;
     datasetDescription =
       "Directory with XML file and one .tif/.tiff file per plane";
+  }
+
+  // -- IHCSReader API methods --
+
+  /* @see loci.formats.IFormatReader#getPlateIdentifier() */
+  public String getPlateIdentifier() throws FormatException, IOException {
+    FormatTools.assertId(currentId, true, 1);
+    return plateID;
   }
 
   // -- IFormatReader API methods --
@@ -338,6 +347,7 @@ public class ColumbusReader extends FormatReader {
     store.setScreenName(handler.getScreenName(), 0);
     store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
     store.setPlateName(handler.getPlateName(), 0);
+    store.setPlateExternalIdentifier(plateID, 0);
     store.setPlateRows(new PositiveInteger(handler.getPlateRows()), 0);
     store.setPlateColumns(new PositiveInteger(handler.getPlateColumns()), 0);
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -343,16 +343,23 @@ public class ColumbusReader extends FormatReader {
 
         p.series = wellSample;
         wellSample++;
+
+        store.setPixelsPhysicalSizeX(new PositiveFloat(p.sizeX), p.series);
+        store.setPixelsPhysicalSizeY(new PositiveFloat(p.sizeY), p.series);
+      }
+      else {
+        p.series = wellSample - 1;
       }
 
-      store.setChannelName(p.channelName, p.series, p.channel);
-      store.setChannelEmissionWavelength(
-        new PositiveInteger((int) p.emWavelength), p.series, p.channel);
-      store.setChannelExcitationWavelength(
-        new PositiveInteger((int) p.exWavelength), p.series, p.channel);
-      store.setChannelColor(p.channelColor, p.series, p.channel);
-      store.setPixelsPhysicalSizeX(new PositiveFloat(p.sizeX), p.series);
-      store.setPixelsPhysicalSizeY(new PositiveFloat(p.sizeY), p.series);
+      if (plane % getImageCount() < getSizeC()) {
+        store.setChannelName(p.channelName, p.series, p.channel);
+        store.setChannelEmissionWavelength(
+          new PositiveInteger((int) p.emWavelength), p.series, p.channel);
+        store.setChannelExcitationWavelength(
+          new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+        store.setChannelColor(p.channelColor, p.series, p.channel);
+      }
+
       store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, p.channel, p.timepoint));
     }
   }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -69,6 +69,7 @@ public class ColumbusReader extends FormatReader implements IHCSReader {
 
   private ArrayList<String> metadataFiles = new ArrayList<String>();
   private ArrayList<String> imageIndexPaths = new ArrayList<String>();
+  private ArrayList<String> annotationPaths = new ArrayList<String>();
   private ArrayList<HarmonyColumbusPlane> planes = new ArrayList<HarmonyColumbusPlane>();
   private HarmonyColumbusHandler imageHandler;
   private MinimalTiffReader reader;
@@ -177,6 +178,7 @@ public class ColumbusReader extends FormatReader implements IHCSReader {
       plateID = null;
       imageHandler = null;
       imageIndexPaths.clear();
+      annotationPaths.clear();
     }
   }
 
@@ -312,7 +314,10 @@ public class ColumbusReader extends FormatReader implements IHCSReader {
 
     store.setScreenID(MetadataTools.createLSID("Screen", 0), 0);
     store.setScreenName(handler.getScreenName(), 0);
-    store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+    String plate = MetadataTools.createLSID("Plate", 0);
+    store.setPlateID(plate, 0);
+    store.setScreenPlateRef(plate, 0, 0);
+
     store.setPlateName(imageHandler.getPlateName(), 0);
     store.setPlateDescription(imageHandler.getPlateDescription(), 0);
     store.setPlateExternalIdentifier(plateID, 0);
@@ -540,6 +545,11 @@ public class ColumbusReader extends FormatReader implements IHCSReader {
         if (type != null && type.equals("IMAGEINDEX") && value.endsWith(".xml")) {
           String path = new Location(currentId).getAbsoluteFile().getParent() + File.separator + value;
           imageIndexPaths.add(new Location(path).getAbsolutePath());
+        }
+        else if (type != null && type.equals("ANNOTATION")) {
+          String path = new Location(currentId).getAbsoluteFile().getParent() + File.separator + value;
+          annotationPaths.add(new Location(path).getAbsolutePath());
+          addGlobalMetaList("Annotation file", value);
         }
       }
       else if (currentName.equals("PlateRows")) {

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -459,7 +459,6 @@ public class ColumbusReader extends FormatReader implements IHCSReader {
       Node child = children.item(q);
       String name = child.getNodeName();
       String value = child.getTextContent();
-      /* debug */ System.out.println(name + " = " + value);
       if ("PlateID".equals(name)) {
         plateID = value;
       }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -232,7 +232,7 @@ public class ColumbusReader extends FormatReader {
     for (int i=0; i<metadataFiles.size(); i++) {
       String path = new Location(parent + File.separator + metadataFiles.get(i)).getAbsolutePath();
       metadataFiles.set(i, path);
-      if (checkSuffix(path, "ColumbusIDX.xml")) {
+      if (checkSuffix(path, "columbusidx.xml")) {
         parseImageXML(path);
       }
     }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -374,18 +374,22 @@ public class ColumbusReader extends FormatReader {
 
             for (int c=0; c<getSizeC(); c++) {
               p = lookupPlane(row, col, field, 0, c);
-              p.series = wellSample;
-              store.setChannelName(p.channelName, p.series, p.channel);
-              store.setChannelEmissionWavelength(
-                new PositiveInteger((int) p.emWavelength), p.series, p.channel);
-              store.setChannelExcitationWavelength(
-                new PositiveInteger((int) p.exWavelength), p.series, p.channel);
-              store.setChannelColor(p.channelColor, p.series, p.channel);
+              if (p != null) {
+                p.series = wellSample;
+                store.setChannelName(p.channelName, p.series, p.channel);
+                store.setChannelEmissionWavelength(
+                  new PositiveInteger((int) p.emWavelength), p.series, p.channel);
+                store.setChannelExcitationWavelength(
+                  new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+                store.setChannelColor(p.channelColor, p.series, p.channel);
+              }
 
               for (int t=0; t<getSizeT(); t++) {
                 p = lookupPlane(row, col, field, t, c);
-                p.series = wellSample;
-                store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, c, t));
+                if (p != null) {
+                  p.series = wellSample;
+                  store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, c, t));
+                }
               }
             }
           }
@@ -548,6 +552,8 @@ public class ColumbusReader extends FormatReader {
         return p;
       }
     }
+    LOGGER.warn("Could not find plane for row={}, column={}, field={}, t={}, c={}",
+      new Object[] {row, col, field, t, c});
     return null;
   }
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -235,9 +235,11 @@ public class ColumbusReader extends FormatReader {
 
     String[] parentDirectories = parent.list(true);
     Arrays.sort(parentDirectories);
+    ArrayList<String> timepointDirs = new ArrayList<String>();
     for (String file : parentDirectories) {
       Location absFile = new Location(parent, file);
       if (absFile.isDirectory()) {
+        timepointDirs.add(absFile.getAbsolutePath());
         for (String f : absFile.list(true)) {
           if (!checkSuffix(f, "tif")) {
             if (!metadataFiles.contains(file + File.separator + f)) {
@@ -251,11 +253,12 @@ public class ColumbusReader extends FormatReader {
     for (int i=0; i<metadataFiles.size(); i++) {
       String metadataFile = metadataFiles.get(i);
       int end = metadataFile.indexOf(File.separator);
-      String timepointPath = end < 0 ? "" : metadataFile.substring(0, end);
+      String timepointPath =
+        end < 0 ? "" : parent + File.separator + metadataFile.substring(0, end);
       String path = new Location(parent + File.separator + metadataFile).getAbsolutePath();
       metadataFiles.set(i, path);
       if (checkSuffix(path, "columbusidx.xml")) {
-        parseImageXML(path, DataTools.indexOf(parentDirectories, timepointPath));
+        parseImageXML(path, timepointDirs.indexOf(timepointPath));
       }
     }
 

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -52,6 +52,10 @@ import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
 
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+import ome.units.UNITS;
+
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.w3c.dom.Attr;
@@ -380,8 +384,8 @@ public class ColumbusReader extends FormatReader {
           store.setWellSampleIndex(new NonNegativeInteger(wellSample), 0, nextWell, field);
 
           if (p != null) {
-            store.setWellSamplePositionX(p.positionX, 0, nextWell, field);
-            store.setWellSamplePositionY(p.positionY, 0, nextWell, field);
+            store.setWellSamplePositionX(new Length(p.positionX, UNITS.REFERENCEFRAME), 0, nextWell, field);
+            store.setWellSamplePositionY(new Length(p.positionY, UNITS.REFERENCEFRAME), 0, nextWell, field);
           }
 
           String imageID = MetadataTools.createLSID("Image", wellSample);
@@ -394,8 +398,8 @@ public class ColumbusReader extends FormatReader {
           if (p != null) {
             p.series = wellSample;
 
-            store.setPixelsPhysicalSizeX(new PositiveFloat(p.sizeX), p.series);
-            store.setPixelsPhysicalSizeY(new PositiveFloat(p.sizeY), p.series);
+            store.setPixelsPhysicalSizeX(FormatTools.getPhysicalSizeX(p.sizeX), p.series);
+            store.setPixelsPhysicalSizeY(FormatTools.getPhysicalSizeY(p.sizeY), p.series);
 
             for (int c=0; c<getSizeC(); c++) {
               p = lookupPlane(row, col, field, 0, c);
@@ -404,11 +408,11 @@ public class ColumbusReader extends FormatReader {
                 store.setChannelName(p.channelName, p.series, p.channel);
                 if ((int) p.emWavelength > 0) {
                   store.setChannelEmissionWavelength(
-                    new PositiveInteger((int) p.emWavelength), p.series, p.channel);
+                    FormatTools.getEmissionWavelength(p.emWavelength), p.series, p.channel);
                 }
                 if ((int) p.exWavelength > 0) {
                   store.setChannelExcitationWavelength(
-                    new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+                    FormatTools.getExcitationWavelength(p.exWavelength), p.series, p.channel);
                 }
                 store.setChannelColor(p.channelColor, p.series, p.channel);
               }
@@ -417,7 +421,7 @@ public class ColumbusReader extends FormatReader {
                 p = lookupPlane(row, col, field, t, c);
                 if (p != null) {
                   p.series = wellSample;
-                  store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, c, t));
+                  store.setPlaneDeltaT(new Time(p.deltaT - timestampSeconds, UNITS.S), p.series, getIndex(0, c, t));
                 }
               }
             }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -370,6 +370,7 @@ public class ColumbusReader extends FormatReader {
 
             for (int c=0; c<getSizeC(); c++) {
               p = lookupPlane(row, col, field, 0, c);
+              p.series = wellSample;
               store.setChannelName(p.channelName, p.series, p.channel);
               store.setChannelEmissionWavelength(
                 new PositiveInteger((int) p.emWavelength), p.series, p.channel);
@@ -379,6 +380,7 @@ public class ColumbusReader extends FormatReader {
 
               for (int t=0; t<getSizeT(); t++) {
                 p = lookupPlane(row, col, field, t, c);
+                p.series = wellSample;
                 store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, c, t));
               }
             }

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -339,6 +339,10 @@ public class ColumbusReader extends FormatReader {
 
     for (Integer row : uniqueRows) {
       for (Integer col : uniqueCols) {
+        if (!uniqueSamples.contains(row * handler.getPlateColumns() + col)) {
+          continue;
+        }
+
         nextWell++;
         store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
         store.setWellRow(new NonNegativeInteger(row), 0, nextWell);

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -398,6 +398,7 @@ public class ColumbusReader extends FormatReader {
   // -- Helper methods --
 
   private void parseImageXML(String filename) throws FormatException, IOException {
+    LOGGER.info("Parsing image data from {}", filename);
     String xml = DataTools.readFile(filename);
     Location parent = new Location(filename).getParentFile();
 
@@ -417,10 +418,12 @@ public class ColumbusReader extends FormatReader {
 
     NodeList plates = root.getElementsByTagName("Plates");
     if (plates == null) {
+      LOGGER.debug("Plates node not found");
       return;
     }
     plates = ((Element) plates.item(0)).getElementsByTagName("Plate");
     if (plates == null) {
+      LOGGER.debug("Plate nodes not found");
       return;
     }
     NodeList timestamps = ((Element) plates.item(0)).getElementsByTagName("MeasurementStartTime");
@@ -428,13 +431,16 @@ public class ColumbusReader extends FormatReader {
 
     NodeList images = root.getElementsByTagName("Images");
     if (images == null) {
+      LOGGER.debug("Images node not found");
       return;
     }
     images = ((Element) images.item(0)).getElementsByTagName("Image");
     if (images == null) {
+      LOGGER.debug("Image nodes not found");
       return;
     }
 
+    LOGGER.debug("Found {} image definitions", images.getLength());
     for (int i=0; i<images.getLength(); i++) {
       Element image = (Element) images.item(i);
       Plane p = new Plane();

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -1,0 +1,599 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2014 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import javax.xml.parsers.ParserConfigurationException;
+
+import loci.common.Constants;
+import loci.common.DataTools;
+import loci.common.Location;
+import loci.common.RandomAccessInputStream;
+import loci.common.xml.BaseHandler;
+import loci.common.xml.XMLTools;
+import loci.formats.CoreMetadata;
+import loci.formats.FormatException;
+import loci.formats.FormatReader;
+import loci.formats.FormatTools;
+import loci.formats.MetadataTools;
+import loci.formats.meta.MetadataStore;
+
+import ome.xml.model.primitives.Color;
+import ome.xml.model.primitives.NonNegativeInteger;
+import ome.xml.model.primitives.PositiveFloat;
+import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+
+
+/**
+ * ColumbusReader is the file format reader for screens exported from PerkinElmer Columbus.
+ *
+ * @author Melissa Linkert melissa at glencoesoftware.com
+ */
+public class ColumbusReader extends FormatReader {
+
+  // -- Constants --
+
+  private static final String XML_FILE = "MeasurementIndex.ColumbusIDX.xml";
+  private static final String MAGIC = "ColumbusMeasurementIndex";
+
+  // -- Fields --
+
+  private ArrayList<String> metadataFiles = new ArrayList<String>();
+  private ArrayList<Plane> planes = new ArrayList<Plane>();
+  private MinimalTiffReader reader;
+
+  private int nFields = 0;
+  private String acquisitionDate;
+
+  // -- Constructor --
+
+  /** Constructs a new Columbus reader. */
+  public ColumbusReader() {
+    super("PerkinElmer Columbus", new String[] {"xml"});
+    domains = new String[] {FormatTools.HCS_DOMAIN};
+    suffixSufficient = false;
+    datasetDescription =
+      "Directory with XML file and one .tif/.tiff file per plane";
+  }
+
+  // -- IFormatReader API methods --
+
+  /* @see loci.formats.IFormatReader#getRequiredDirectories(String[]) */
+  public int getRequiredDirectories(String[] files)
+    throws FormatException, IOException
+  {
+    return 2;
+  }
+
+  /* @see loci.formats.IFormatReader#isSingleFile(String) */
+  public boolean isSingleFile(String id) throws FormatException, IOException {
+    return false;
+  }
+
+  /* @see loci.formats.IFormatReader#fileGroupOption(String) */
+  public int fileGroupOption(String id) throws FormatException, IOException {
+    return FormatTools.MUST_GROUP;
+  }
+
+  /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
+  public boolean isThisType(String name, boolean open) {
+    String localName = new Location(name).getName();
+    if (localName.equals(XML_FILE)) {
+      return true;
+    }
+    Location parent = new Location(name).getAbsoluteFile().getParentFile();
+    parent = parent.getParentFile();
+    Location xml = new Location(parent, XML_FILE);
+    if (!xml.exists()) {
+      return false;
+    }
+
+    return super.isThisType(name, open);
+  }
+
+  /* @see loci.formats.IFormatReader#isThisType(RandomAccessInputStream) */
+  public boolean isThisType(RandomAccessInputStream stream) throws IOException {
+    String check = stream.readString(1024);
+    return check.indexOf(MAGIC) > 0;
+  }
+
+  /* @see loci.formats.IFormatReader#getSeriesUsedFiles(boolean) */
+  public String[] getSeriesUsedFiles(boolean noPixels) {
+    FormatTools.assertId(currentId, true, 1);
+
+    ArrayList<String> files = new ArrayList<String>();
+    files.add(currentId);
+    for (String file : metadataFiles) {
+      files.add(file);
+    }
+
+    if (!noPixels) {
+      for (Plane p : planes) {
+        if (p.series == getSeries() && !files.contains(p.file)) {
+          files.add(p.file);
+        }
+      }
+    }
+
+    return files.toArray(new String[files.size()]);
+  }
+
+  /* @see loci.formats.IFormatReader#close(boolean) */
+  public void close(boolean fileOnly) throws IOException {
+    super.close(fileOnly);
+    if (!fileOnly) {
+      if (reader != null) {
+        reader.close();
+      }
+      reader = null;
+      metadataFiles.clear();
+      planes.clear();
+      nFields = 0;
+      acquisitionDate = null;
+    }
+  }
+
+  /**
+   * @see loci.formats.IFormatReader#openBytes(int, byte[], int, int, int, int)
+   */
+  public byte[] openBytes(int no, byte[] buf, int x, int y, int w, int h)
+    throws FormatException, IOException
+  {
+    FormatTools.checkPlaneParameters(this, no, buf.length, x, y, w, h);
+
+    int index = getSeries() * getImageCount() + no;
+    Plane p = planes.get(index);
+
+    reader.setId(p.file);
+    reader.openBytes(p.fileIndex, buf, x, y, w, h);
+    return buf;
+  }
+
+  // -- Internal FormatReader API methods --
+
+  /* @see loci.formats.FormatReader#initFile(String) */
+  protected void initFile(String id) throws FormatException, IOException {
+    // make sure that we have the XML file and not a TIFF file
+
+    if (!checkSuffix(id, "xml")) {
+      Location parent = new Location(id).getAbsoluteFile().getParentFile();
+      Location xml = new Location(parent, XML_FILE);
+      if (!xml.exists()) {
+        throw new FormatException("Could not find XML file " +
+          xml.getAbsolutePath());
+      }
+      initFile(xml.getAbsolutePath());
+      return;
+    }
+    else {
+      super.initFile(id);
+    }
+
+    Location parent = new Location(currentId).getAbsoluteFile().getParentFile();
+
+    // parse plate layout and image dimensions from the XML files
+
+    String xmlData = DataTools.readFile(id);
+    MeasurementHandler handler = new MeasurementHandler();
+    XMLTools.parseXML(xmlData, handler);
+
+    for (String file : metadataFiles) {
+      if (checkSuffix(file, "xml")) {
+        parseImageXML(new Location(parent, file).getAbsolutePath());
+      }
+    }
+
+    // process plane list to determine plate size
+
+    Comparator<Plane> planeComp = new Comparator<Plane>() {
+      public int compare(Plane p1, Plane p2) {
+        if (p1.row != p2.row) {
+          return p1.row - p2.row;
+        }
+
+        if (p1.col != p2.col) {
+          return p1.col - p2.col;
+        }
+
+        if (p1.field != p2.field) {
+          return p1.field - p2.field;
+        }
+
+        if (p1.timepoint != p2.timepoint) {
+          return p1.timepoint - p2.timepoint;
+        }
+
+        if (p1.channel != p2.channel) {
+          return p1.channel - p2.channel;
+        }
+
+        return 0;
+      }
+    };
+    Plane[] tmpPlanes = planes.toArray(new Plane[planes.size()]);
+    Arrays.sort(tmpPlanes, planeComp);
+    planes.clear();
+
+    reader = new MinimalTiffReader();
+    reader.setId(tmpPlanes[0].file);
+    core = reader.getCoreMetadataList();
+
+    CoreMetadata m = core.get(0);
+
+    m.sizeC = 0;
+    m.sizeT = 0;
+
+    ArrayList<Integer> uniqueSamples = new ArrayList<Integer>();
+    for (Plane p : tmpPlanes) {
+      planes.add(p);
+
+      int sampleIndex = p.row * handler.getPlateColumns() + p.col;
+      if (!uniqueSamples.contains(sampleIndex)) {
+        uniqueSamples.add(sampleIndex);
+      }
+
+      // missing wells are allowed, but the field/channel/timepoint
+      // counts are assumed to be non-sparse
+      if (p.field >= nFields) {
+        nFields = p.field + 1;
+      }
+      if (p.channel >= getSizeC()) {
+        m.sizeC = p.channel + 1;
+      }
+      if (p.timepoint >= getSizeT()) {
+        m.sizeT = p.timepoint + 1;
+      }
+
+    }
+
+    m.sizeZ = 1;
+    m.imageCount = getSizeZ() * getSizeC() * getSizeT();
+    m.dimensionOrder = "XYCTZ";
+    m.rgb = false;
+
+    int seriesCount = uniqueSamples.size() * nFields;
+    for (int i=1; i<seriesCount; i++) {
+      core.add(m);
+    }
+
+    // populate the MetadataStore
+
+    MetadataStore store = makeFilterMetadata();
+    MetadataTools.populatePixels(store, this, true);
+
+    store.setScreenID(MetadataTools.createLSID("Screen", 0), 0);
+    store.setScreenName(handler.getScreenName(), 0);
+    store.setPlateID(MetadataTools.createLSID("Plate", 0), 0);
+    store.setPlateName(handler.getPlateName(), 0);
+    store.setPlateRows(new PositiveInteger(handler.getPlateRows()), 0);
+    store.setPlateColumns(new PositiveInteger(handler.getPlateColumns()), 0);
+
+    String imagePrefix = handler.getPlateName() + " Well ";
+    int planeIndex = 0;
+    int wellSample = 0;
+
+    int nextWell = -1;
+    Timestamp date = new Timestamp(acquisitionDate);
+    long timestampSeconds = date.asInstant().getMillis() / 1000;
+    for (int plane=0; plane<planes.size(); plane++) {
+      Plane p = planes.get(plane);
+
+      if (plane % (getImageCount() * nFields) == 0) {
+        nextWell++;
+        store.setWellID(MetadataTools.createLSID("Well", 0, nextWell), 0, nextWell);
+        store.setWellRow(new NonNegativeInteger(p.row), 0, nextWell);
+        store.setWellColumn(new NonNegativeInteger(p.col), 0, nextWell);
+      }
+
+      if (plane % getImageCount() == 0) {
+        String wellSampleID = MetadataTools.createLSID("WellSample", 0, nextWell, p.field);
+        store.setWellSampleID(wellSampleID, 0, nextWell, p.field);
+        store.setWellSampleIndex(new NonNegativeInteger(wellSample), 0, nextWell, p.field);
+        store.setWellSamplePositionX(p.positionX, 0, nextWell, p.field);
+        store.setWellSamplePositionY(p.positionY, 0, nextWell, p.field);
+
+        String imageID = MetadataTools.createLSID("Image", wellSample);
+        store.setImageID(imageID, wellSample);
+        store.setWellSampleImageRef(imageID, 0, nextWell, p.field);
+
+        store.setImageName(
+          imagePrefix + (char) (p.row + 'A') + (p.col + 1) + " Field #" + (p.field + 1), wellSample);
+        store.setImageAcquisitionDate(date, wellSample);
+
+        p.series = wellSample;
+        wellSample++;
+      }
+
+      store.setChannelName(p.channelName, p.series, p.channel);
+      store.setChannelEmissionWavelength(
+        new PositiveInteger((int) p.emWavelength), p.series, p.channel);
+      store.setChannelExcitationWavelength(
+        new PositiveInteger((int) p.exWavelength), p.series, p.channel);
+      store.setChannelColor(p.channelColor, p.series, p.channel);
+      store.setPixelsPhysicalSizeX(new PositiveFloat(p.sizeX), p.series);
+      store.setPixelsPhysicalSizeY(new PositiveFloat(p.sizeY), p.series);
+      store.setPlaneDeltaT(p.deltaT - timestampSeconds, p.series, getIndex(0, p.channel, p.timepoint));
+    }
+  }
+
+  // -- Helper methods --
+
+  private void parseImageXML(String filename) throws FormatException, IOException {
+    String xml = DataTools.readFile(filename);
+    Location parent = new Location(filename).getParentFile();
+
+    Element root = null;
+    try {
+      ByteArrayInputStream s =
+        new ByteArrayInputStream(xml.getBytes(Constants.ENCODING));
+      root = XMLTools.parseDOM(s).getDocumentElement();
+      s.close();
+    }
+    catch (ParserConfigurationException e) {
+      throw new FormatException(e);
+    }
+    catch (SAXException e) {
+      throw new FormatException(e);
+    }
+
+    NodeList plates = root.getElementsByTagName("Plates");
+    plates = ((Element) plates.item(0)).getElementsByTagName("Plate");
+    NodeList timestamps = ((Element) plates.item(0)).getElementsByTagName("MeasurementStartTime");
+    acquisitionDate = ((Element) timestamps.item(0)).getTextContent();
+
+    NodeList images = root.getElementsByTagName("Images");
+    images = ((Element) images.item(0)).getElementsByTagName("Image");
+
+    for (int i=0; i<images.getLength(); i++) {
+      Element image = (Element) images.item(i);
+      Plane p = new Plane();
+
+      NodeList children = image.getChildNodes();
+      for (int q=0; q<children.getLength(); q++) {
+        Node child = children.item(q);
+        String name = child.getNodeName();
+        String value = child.getTextContent();
+        NamedNodeMap attrs = child.getAttributes();
+        if (name.equals("URL")) {
+          p.file = new Location(parent, value).getAbsolutePath();
+
+          String buffer = attrs.getNamedItem("BufferNo").getNodeValue();
+          p.fileIndex = Integer.parseInt(buffer);
+        }
+        else if (name.equals("Row")) {
+          p.row = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("Col")) {
+          p.col = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("FieldID")) {
+          p.field = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("TimepointID")) {
+          p.timepoint = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("ChannelID")) {
+          p.channel = Integer.parseInt(value) - 1;
+        }
+        else if (name.equals("ChannelName")) {
+          p.channelName = value;
+        }
+        else if (name.equals("ChannelColor")) {
+          Long color = new Long(value);
+          int blue = (int) ((color >> 24) & 0xff);
+          int green = (int) ((color >> 16) & 0xff);
+          int red = (int) ((color >> 8) & 0xff);
+          int alpha = (int) (color & 0xff);
+
+          // not setting this yet, and deferring to the
+          // emission wavelength to set the color
+          // neither BGRA nor ARGB seems to make sense for all channels
+          //p.channelColor = new Color(red, green, blue, alpha);
+        }
+        else if (name.equals("MeasurementTimeOffset")) {
+          p.deltaT = new Double(value);
+        }
+        else if (name.equals("MainEmissionWavelength")) {
+          p.emWavelength = new Double(value);
+        }
+        else if (name.equals("MainExcitationWavelength")) {
+          p.exWavelength = new Double(value);
+        }
+        else if (name.equals("ImageResolutionX")) {
+          String unit = attrs.getNamedItem("Unit").getNodeValue();
+          p.sizeX = correctUnits(new Double(value), unit);
+        }
+        else if (name.equals("ImageResolutionY")) {
+          String unit = attrs.getNamedItem("Unit").getNodeValue();
+          p.sizeY = correctUnits(new Double(value), unit);
+        }
+        else if (name.equals("PositionX")) {
+          String unit = attrs.getNamedItem("Unit").getNodeValue();
+          p.positionX = correctUnits(new Double(value), unit);
+        }
+        else if (name.equals("PositionY")) {
+          String unit = attrs.getNamedItem("Unit").getNodeValue();
+          p.positionY = correctUnits(new Double(value), unit);
+        }
+        else if (name.equals("PositionZ")) {
+          String unit = attrs.getNamedItem("Unit").getNodeValue();
+          p.positionZ = correctUnits(new Double(value), unit);
+        }
+      }
+
+      planes.add(p);
+    }
+
+  }
+
+  private Double correctUnits(Double v, String unit) {
+    if (unit == null) {
+      return v;
+    }
+
+    if (unit.equals("m")) {
+      return v * 1000000;
+    }
+    else if (unit.equals("cm")) {
+      return v * 10000;
+    }
+    else if (unit.equals("nm")) {
+      return v /= 1000;
+    }
+    return v;
+  }
+
+  // -- Helper classes --
+
+
+  class MeasurementHandler extends BaseHandler {
+    // -- Fields --
+
+    private String currentName;
+
+    private String screenName;
+    private String plateName;
+    private String plateType;
+    private String measurementID;
+    private String measurementName;
+    private Integer plateRows;
+    private Integer plateColumns;
+
+    // -- MeasurementHandler API methods --
+
+    public String getScreenName() {
+      return screenName;
+    }
+
+    public String getPlateName() {
+      return plateName;
+    }
+
+    public String getPlateType() {
+      return plateType;
+    }
+
+    public String getMeasurementID() {
+      return measurementID;
+    }
+
+    public String getMeasurementName() {
+      return measurementName;
+    }
+
+    public Integer getPlateRows() {
+      return plateRows;
+    }
+
+    public Integer getPlateColumns() {
+      return plateColumns;
+    }
+
+    // -- DefaultHandler API methods --
+
+    public void characters(char[] ch, int start, int length) {
+      String value = new String(ch, start, length);
+      addGlobalMeta(currentName, value);
+
+      if (currentName.equals("ScreenName")) {
+        screenName = value;
+      }
+      else if (currentName.equals("PlateName")) {
+        plateName = value;
+      }
+      else if (currentName.equals("PlateType")) {
+        plateType = value;
+      }
+      else if (currentName.equals("Measurement")) {
+        measurementName = value;
+      }
+      else if (currentName.equals("Reference")) {
+        metadataFiles.add(value);
+      }
+      else if (currentName.equals("PlateRows")) {
+        plateRows = new Integer(value);
+      }
+      else if (currentName.equals("PlateColumns")) {
+        plateColumns = new Integer(value);
+      }
+    }
+
+    public void startElement(String uri, String localName, String qName,
+      Attributes attributes)
+    {
+      currentName = qName;
+
+      for (int i=0; i<attributes.getLength(); i++) {
+        String name = attributes.getQName(i);
+        String value = attributes.getValue(i);
+        if (currentName.equals("Measurement") && name.equals("MeasurementID")) {
+          measurementID = value;
+        }
+      }
+    }
+
+    public void endElement(String uri, String localName, String qName) {
+    }
+
+  }
+
+  class Plane {
+    public String file;
+    public int fileIndex;
+    public int row;
+    public int col;
+    public int field;
+    public int timepoint;
+    public int channel;
+    public double deltaT;
+    public double emWavelength;
+    public double exWavelength;
+    public String channelName;
+    public Color channelColor;
+    public double sizeX;
+    public double sizeY;
+    public double positionX;
+    public double positionY;
+    public double positionZ;
+    public int series;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
+++ b/components/formats-gpl/src/loci/formats/in/ColumbusReader.java
@@ -322,7 +322,6 @@ public class ColumbusReader extends FormatReader {
     Timestamp date = new Timestamp(acquisitionDate);
     long timestampSeconds = date.asInstant().getMillis() / 1000;
     int nextWellSample = 0;
-    int nextSeries = 0;
 
     int prevRow = -1, prevCol = -1;
     for (int plane=0; plane<planes.size(); plane++) {
@@ -336,50 +335,34 @@ public class ColumbusReader extends FormatReader {
 
         prevRow = p.row;
         prevCol = p.col;
+        nextWellSample = 0;
       }
 
       if (plane % getImageCount() == 0) {
-        // fill in empty WellSamples for missing fields
-        boolean addEmptySamples = nextWellSample < p.field;
-        while (nextWellSample < p.field) {
-          String wellSampleID = MetadataTools.createLSID("WellSample", 0, nextWell, nextWellSample);
-          store.setWellSampleID(wellSampleID, 0, nextWell, nextWellSample);
-          store.setWellSampleIndex(new NonNegativeInteger(wellSample), 0, nextWell, nextWellSample);
-          nextWellSample++;
-          wellSample++;
-        }
+        String wellSampleID = MetadataTools.createLSID("WellSample", 0, nextWell, nextWellSample);
+        store.setWellSampleID(wellSampleID, 0, nextWell, nextWellSample);
+        store.setWellSampleIndex(new NonNegativeInteger(wellSample), 0, nextWell, nextWellSample);
+        store.setWellSamplePositionX(p.positionX, 0, nextWell, nextWellSample);
+        store.setWellSamplePositionY(p.positionY, 0, nextWell, nextWellSample);
 
-        if (nextWellSample == nFields - 1) {
-          nextWellSample = 0;
-        }
-
-        String wellSampleID = MetadataTools.createLSID("WellSample", 0, nextWell, p.field);
-        store.setWellSampleID(wellSampleID, 0, nextWell, p.field);
-        store.setWellSampleIndex(new NonNegativeInteger(wellSample), 0, nextWell, p.field);
-        store.setWellSamplePositionX(p.positionX, 0, nextWell, p.field);
-        store.setWellSamplePositionY(p.positionY, 0, nextWell, p.field);
-
-        String imageID = MetadataTools.createLSID("Image", nextSeries);
-        store.setImageID(imageID, nextSeries);
-        store.setWellSampleImageRef(imageID, 0, nextWell, p.field);
+        String imageID = MetadataTools.createLSID("Image", wellSample);
+        store.setImageID(imageID, wellSample);
+        store.setWellSampleImageRef(imageID, 0, nextWell, nextWellSample);
 
         store.setImageName(
-          imagePrefix + (char) (p.row + 'A') + (p.col + 1) + " Field #" + (p.field + 1), nextSeries);
-        store.setImageAcquisitionDate(date, nextSeries);
+          imagePrefix + (char) (p.row + 'A') + (p.col + 1) + " Field #" + (p.field + 1), wellSample);
+        store.setImageAcquisitionDate(date, wellSample);
 
-        p.series = nextSeries;
+        p.series = wellSample;
         wellSample++;
-        nextSeries++;
 
-        if (!addEmptySamples && p.field < nFields - 1) {
-          nextWellSample++;
-        }
+        nextWellSample++;
 
         store.setPixelsPhysicalSizeX(new PositiveFloat(p.sizeX), p.series);
         store.setPixelsPhysicalSizeY(new PositiveFloat(p.sizeY), p.series);
       }
       else {
-        p.series = nextSeries - 1;
+        p.series = wellSample - 1;
       }
 
       if (plane % getImageCount() < getSizeC()) {

--- a/components/formats-gpl/src/loci/formats/in/HarmonyColumbusHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyColumbusHandler.java
@@ -1,0 +1,277 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+
+package loci.formats.in;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import loci.common.Location;
+import loci.common.xml.BaseHandler;
+
+import org.xml.sax.Attributes;
+
+public class HarmonyColumbusHandler extends BaseHandler {
+  private static final String ROOT_ELEMENT = "EvaluationInputData";
+
+  // -- Fields --
+
+  private String currentId;
+
+  private String currentName;
+  private HarmonyColumbusPlane activePlane;
+  private String currentUnit;
+
+  private String displayName;
+  private String plateID;
+  private String measurementTime;
+  private String plateName;
+  private String plateDescription;
+  private int plateRows, plateCols;
+  private ArrayList<HarmonyColumbusPlane> planes = new ArrayList<HarmonyColumbusPlane>();
+
+  private StringBuffer currentValue = new StringBuffer();
+
+  private ArrayList<String> elementNames = new ArrayList<String>();
+
+  private HashMap<String, String> metadata = new HashMap<String, String>();
+  private HashMap<String, Integer> keyCounter = new HashMap<String, Integer>();
+
+  public HarmonyColumbusHandler(String currentId) {
+    super();
+    this.currentId = currentId;
+  }
+
+  // -- HarmonyHandler API methods --
+
+  public HashMap<String, String> getMetadataMap() {
+    return metadata;
+  }
+
+  public ArrayList<HarmonyColumbusPlane> getPlanes() {
+    return planes;
+  }
+
+  public String getExperimenterName() {
+    return displayName;
+  }
+
+  public String getPlateIdentifier() {
+    return plateID;
+  }
+
+  public String getMeasurementTime() {
+    return measurementTime;
+  }
+
+  public String getPlateName() {
+    return plateName;
+  }
+
+  public String getPlateDescription() {
+    return plateDescription;
+  }
+
+  public int getPlateRows() {
+    return plateRows;
+  }
+
+  public int getPlateColumns() {
+    return plateCols;
+  }
+
+  // -- DefaultHandler API methods --
+
+  @Override
+  public void characters(char[] ch, int start, int length) {
+    String value = new String(ch, start, length);
+    currentValue.append(value);
+  }
+
+  @Override
+  public void startElement(String uri, String localName, String qName,
+    Attributes attributes)
+  {
+    if (!qName.equals(ROOT_ELEMENT)) {
+      elementNames.add(qName);
+    }
+    currentValue.setLength(0);
+
+    if (qName.equals("Image") && attributes.getValue("id") == null) {
+      activePlane = new HarmonyColumbusPlane();
+    }
+
+    currentUnit = attributes.getValue("Unit");
+  }
+
+  @Override
+  public void endElement(String uri, String localName, String qName) {
+    String value = currentValue.toString();
+
+    int elementCount = elementNames.size();
+    String currentName = null;
+    if (elementCount > 0) {
+      currentName = elementNames.get(elementCount - 1);
+    }
+    String parentName = null;
+    if (elementCount > 1) {
+      parentName = elementNames.get(elementCount - 2);
+    }
+
+    if (parentName == null) {
+      metadata.put(currentName, value);
+    }
+    else {
+      int keyCount = 1;
+      if (keyCounter.containsKey(parentName)) {
+        keyCount = keyCounter.get(parentName);
+      }
+
+      metadata.put(parentName + " #" + keyCount + " " + currentName, value);
+    }
+
+    if (keyCounter.containsKey(currentName) || elementNames.size() == 2) {
+      int keyCount = 1;
+      if (keyCounter.containsKey(currentName)) {
+        keyCount = keyCounter.get(currentName);
+      }
+      keyCounter.put(currentName, keyCount + 1);
+    }
+
+    if ("Plate".equals(parentName)) {
+      if ("Name".equals(currentName)) {
+        plateName = value;
+      }
+      else if ("PlateTypeName".equals(currentName)) {
+        plateDescription = value;
+      }
+      else if ("PlateRows".equals(currentName)) {
+        plateRows = Integer.parseInt(value);
+      }
+      else if ("PlateColumns".equals(currentName)) {
+        plateCols = Integer.parseInt(value);
+      }
+      else if ("PlateID".equals(currentName)) {
+        plateID = value;
+      }
+      else if ("MeasurementStartTime".equals(currentName)) {
+        measurementTime = value;
+      }
+    }
+
+    if ("User".equals(currentName)) {
+      displayName = value;
+    }
+    else if (activePlane != null && "Image".equals(parentName)) {
+      if ("URL".equals(currentName)) {
+        if (value.startsWith("http")) {
+          activePlane.filename = value;
+        }
+        else {
+          Location parent =
+            new Location(currentId).getAbsoluteFile().getParentFile();
+          activePlane.filename = new Location(parent, value).getAbsolutePath();
+        }
+      }
+      else if ("Row".equals(currentName)) {
+        activePlane.row = Integer.parseInt(value) - 1;
+      }
+      else if ("Col".equals(currentName)) {
+        activePlane.col = Integer.parseInt(value) - 1;
+      }
+      else if ("FieldID".equals(currentName)) {
+        activePlane.field = Integer.parseInt(value);
+      }
+      else if ("PlaneID".equals(currentName)) {
+        activePlane.z = Integer.parseInt(value);
+      }
+      else if ("ImageSizeX".equals(currentName)) {
+        activePlane.x = Integer.parseInt(value);
+      }
+      else if ("ImageSizeY".equals(currentName)) {
+        activePlane.y = Integer.parseInt(value);
+      }
+      else if ("TimepointID".equals(currentName)) {
+        activePlane.t = Integer.parseInt(value);
+      }
+      else if ("ChannelID".equals(currentName)) {
+        activePlane.c = Integer.parseInt(value);
+      }
+      else if ("ChannelName".equals(currentName)) {
+        activePlane.channelName = value;
+      }
+      else if ("ImageResolutionX".equals(currentName)) {
+        activePlane.setResolutionX(value, currentUnit);
+      }
+      else if ("ImageResolutionY".equals(currentName)) {
+        activePlane.setResolutionY(value, currentUnit);
+      }
+      else if ("PositionX".equals(currentName)) {
+        activePlane.setPositionX(value, currentUnit);
+      }
+      else if ("PositionY".equals(currentName)) {
+        activePlane.setPositionY(value, currentUnit);
+      }
+      else if ("PositionZ".equals(currentName)) {
+        activePlane.setPositionZ(value, currentUnit);
+      }
+      else if ("MeasurementTimeOffset".equals(currentName)) {
+        activePlane.setDeltaT(value, currentUnit);
+      }
+      else if ("ObjectiveMagnification".equals(currentName)) {
+        activePlane.magnification = Double.parseDouble(value);
+      }
+      else if ("ObjectiveNA".equals(currentName)) {
+        activePlane.lensNA = Double.parseDouble(value);
+      }
+      else if ("MainEmissionWavelength".equals(currentName)) {
+        activePlane.setEmWavelength(value, currentUnit);
+      }
+      else if ("MainExcitationWavelength".equals(currentName)) {
+        activePlane.setExWavelength(value, currentUnit);
+      }
+      else if ("AcquisitionType".equals(currentName)) {
+        activePlane.acqType = value;
+      }
+      else if ("ChannelType".equals(currentName)) {
+        activePlane.channelType = value;
+      }
+      else if ("AbsTime".equals(currentName)) {
+        activePlane.acqTime = value;
+      }
+    }
+
+    if (qName.equals("Image") && activePlane != null) {
+      planes.add(activePlane);
+    }
+
+    if (!qName.equals(ROOT_ELEMENT)) {
+      elementNames.remove(elementNames.size() - 1);
+    }
+    currentUnit = null;
+  }
+
+}

--- a/components/formats-gpl/src/loci/formats/in/HarmonyColumbusHandler.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyColumbusHandler.java
@@ -60,6 +60,8 @@ public class HarmonyColumbusHandler extends BaseHandler {
   private HashMap<String, String> metadata = new HashMap<String, String>();
   private HashMap<String, Integer> keyCounter = new HashMap<String, Integer>();
 
+  private Attributes currentAttributes;
+
   public HarmonyColumbusHandler(String currentId) {
     super();
     this.currentId = currentId;
@@ -125,11 +127,22 @@ public class HarmonyColumbusHandler extends BaseHandler {
     }
 
     currentUnit = attributes.getValue("Unit");
+    currentAttributes = attributes;
   }
 
   @Override
   public void endElement(String uri, String localName, String qName) {
     String value = currentValue.toString();
+    if (value.trim().length() == 0) {
+      if (qName.equals("Image") && activePlane != null) {
+        planes.add(activePlane);
+      }
+      if (!qName.equals(ROOT_ELEMENT)) {
+        elementNames.remove(elementNames.size() - 1);
+      }
+      currentUnit = null;
+      return;
+    }
 
     int elementCount = elementNames.size();
     String currentName = null;
@@ -194,6 +207,10 @@ public class HarmonyColumbusHandler extends BaseHandler {
           Location parent =
             new Location(currentId).getAbsoluteFile().getParentFile();
           activePlane.filename = new Location(parent, value).getAbsolutePath();
+        }
+        String buffer = currentAttributes.getValue("BufferNo");
+        if (buffer != null) {
+          activePlane.fileIndex = Integer.parseInt(buffer);
         }
       }
       else if ("Row".equals(currentName)) {

--- a/components/formats-gpl/src/loci/formats/in/HarmonyColumbusPlane.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyColumbusPlane.java
@@ -1,0 +1,157 @@
+/*
+ * #%L
+ * OME Bio-Formats package for reading and converting biological file formats.
+ * %%
+ * Copyright (C) 2005 - 2016 Open Microscopy Environment:
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ *   - University of Dundee
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package loci.formats.in;
+
+import loci.formats.FormatTools;
+
+import ome.units.quantity.Length;
+import ome.units.quantity.Time;
+
+import ome.xml.model.enums.EnumerationException;
+import ome.xml.model.enums.UnitsLength;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HarmonyColumbusPlane implements Comparable<HarmonyColumbusPlane> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HarmonyColumbusPlane.class);
+
+  public String filename;
+  public int fileIndex;
+  public int series;
+  public int row;
+  public int col;
+  public int field;
+  public int image = -1;
+  public int x;
+  public int y;
+  public int z;
+  public int t;
+  public int c;
+  public String channelName;
+  public Length resolutionX;
+  public Length resolutionY;
+  public Length positionX;
+  public Length positionY;
+  public Length positionZ;
+  public Time deltaT;
+  public Length emWavelength;
+  public Length exWavelength;
+  public double magnification;
+  public double lensNA;
+  public String acqType;
+  public String channelType;
+  public String acqTime;
+
+  @Override
+  public int compareTo(HarmonyColumbusPlane p) {
+     if (this.row != p.row) {
+       return this.row - p.row;
+     }
+
+     if (this.col != p.col) {
+       return this.col - p.col;
+     }
+
+     if (this.field != p.field) {
+       return this.field - p.field;
+     }
+
+     if (this.t != p.t) {
+       return this.t - p.t;
+     }
+
+     if (this.c != p.c) {
+       return this.c - p.c;
+     }
+
+     return 0;
+  }
+
+  public void setPositionX(String value, String unit) {
+    final double x = Double.parseDouble(value);
+    try {
+      UnitsLength ul = UnitsLength.fromString(unit);
+      positionX = UnitsLength.create(x, ul);
+    }
+    catch (EnumerationException e) {
+      LOGGER.debug("Could not parse unit '{}'", unit);
+    }
+  }
+
+  public void setPositionY(String value, String unit) {
+    final double y = Double.parseDouble(value);
+    try {
+      UnitsLength ul = UnitsLength.fromString(unit);
+      positionY = UnitsLength.create(y, ul);
+    }
+    catch (EnumerationException e) {
+      LOGGER.debug("Could not parse unit '{}'", unit);
+    }
+  }
+
+  public void setPositionZ(String value, String unit) {
+    final double z = Double.parseDouble(value);
+    try {
+      UnitsLength ul = UnitsLength.fromString(unit);
+      positionZ = UnitsLength.create(z, ul);
+    }
+    catch (EnumerationException e) {
+      LOGGER.debug("Could not parse unit '{}'", unit);
+    }
+  }
+
+  public void setEmWavelength(String value, String unit) {
+    final double wave = Double.parseDouble(value);
+    if (wave > 0) {
+      emWavelength = FormatTools.getWavelength(wave, unit);
+    }
+  }
+
+  public void setExWavelength(String value, String unit) {
+    final double wave = Double.parseDouble(value);
+    if (wave > 0) {
+      exWavelength = FormatTools.getWavelength(wave, unit);
+    }
+  }
+
+  public void setResolutionX(String value, String unit) {
+    resolutionX = FormatTools.getPhysicalSizeX(Double.parseDouble(value), unit);
+  }
+
+  public void setResolutionY(String value, String unit) {
+    resolutionY = FormatTools.getPhysicalSizeY(Double.parseDouble(value), unit);
+  }
+
+  public void setDeltaT(String value, String unit) {
+    final double t = Double.parseDouble(value);
+    deltaT = FormatTools.getTime(t, unit);
+  }
+
+}
+
+

--- a/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
+++ b/components/formats-gpl/src/loci/formats/in/HarmonyReader.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import loci.common.DataTools;
 import loci.common.Location;
 import loci.common.RandomAccessInputStream;
-import loci.common.xml.BaseHandler;
 import loci.common.xml.XMLTools;
 import loci.formats.CoreMetadata;
 import loci.formats.FormatException;
@@ -50,11 +49,8 @@ import ome.units.quantity.Length;
 import ome.units.unit.Unit;
 import ome.xml.model.enums.AcquisitionMode;
 import ome.xml.model.primitives.NonNegativeInteger;
-import ome.xml.model.primitives.PositiveFloat;
 import ome.xml.model.primitives.PositiveInteger;
 import ome.xml.model.primitives.Timestamp;
-
-import org.xml.sax.Attributes;
 
 /**
  * HarmonyReader is the file format reader for PerkinElmer Harmony data.
@@ -305,7 +301,7 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
 
     LOGGER.info("Parsing XML metadata");
     String xmlData = DataTools.readFile(id);
-    HarmonyHandler handler = new HarmonyHandler();
+    HarmonyColumbusHandler handler = new HarmonyColumbusHandler(currentId);
     XMLTools.parseXML(xmlData, handler);
 
     // sort the list of images by well and field indices
@@ -512,243 +508,6 @@ public class HarmonyReader extends FormatReader implements IHCSReader {
       }
 
     }
-  }
-
-  // -- Helper classes --
-
-  class HarmonyHandler extends BaseHandler {
-    private static final String ROOT_ELEMENT = "EvaluationInputData";
-
-    // -- Fields --
-
-    private String currentName;
-    private HarmonyColumbusPlane activePlane;
-    private String currentUnit;
-
-    private String displayName;
-    private String plateID;
-    private String measurementTime;
-    private String plateName;
-    private String plateDescription;
-    private int plateRows, plateCols;
-    private ArrayList<HarmonyColumbusPlane> planes = new ArrayList<HarmonyColumbusPlane>();
-
-    private StringBuffer currentValue = new StringBuffer();
-
-    private ArrayList<String> elementNames = new ArrayList<String>();
-
-    private HashMap<String, String> metadata = new HashMap<String, String>();
-    private HashMap<String, Integer> keyCounter = new HashMap<String, Integer>();
-
-    // -- HarmonyHandler API methods --
-
-    public HashMap<String, String> getMetadataMap() {
-      return metadata;
-    }
-
-    public ArrayList<HarmonyColumbusPlane> getPlanes() {
-      return planes;
-    }
-
-    public String getExperimenterName() {
-      return displayName;
-    }
-
-    public String getPlateIdentifier() {
-      return plateID;
-    }
-
-    public String getMeasurementTime() {
-      return measurementTime;
-    }
-
-    public String getPlateName() {
-      return plateName;
-    }
-
-    public String getPlateDescription() {
-      return plateDescription;
-    }
-
-    public int getPlateRows() {
-      return plateRows;
-    }
-
-    public int getPlateColumns() {
-      return plateCols;
-    }
-
-    // -- DefaultHandler API methods --
-
-    @Override
-    public void characters(char[] ch, int start, int length) {
-      String value = new String(ch, start, length);
-      currentValue.append(value);
-    }
-
-    @Override
-    public void startElement(String uri, String localName, String qName,
-      Attributes attributes)
-    {
-      if (!qName.equals(ROOT_ELEMENT)) {
-        elementNames.add(qName);
-      }
-      currentValue.setLength(0);
-
-      if (qName.equals("Image") && attributes.getValue("id") == null) {
-        activePlane = new HarmonyColumbusPlane();
-      }
-
-      currentUnit = attributes.getValue("Unit");
-    }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) {
-      String value = currentValue.toString();
-
-      int elementCount = elementNames.size();
-      String currentName = null;
-      if (elementCount > 0) {
-        currentName = elementNames.get(elementCount - 1);
-      }
-      String parentName = null;
-      if (elementCount > 1) {
-        parentName = elementNames.get(elementCount - 2);
-      }
-
-      if (parentName == null) {
-        metadata.put(currentName, value);
-      }
-      else {
-        int keyCount = 1;
-        if (keyCounter.containsKey(parentName)) {
-          keyCount = keyCounter.get(parentName);
-        }
-
-        metadata.put(parentName + " #" + keyCount + " " + currentName, value);
-      }
-
-      if (keyCounter.containsKey(currentName) || elementNames.size() == 2) {
-        int keyCount = 1;
-        if (keyCounter.containsKey(currentName)) {
-          keyCount = keyCounter.get(currentName);
-        }
-        keyCounter.put(currentName, keyCount + 1);
-      }
-
-      if ("Plate".equals(parentName)) {
-        if ("Name".equals(currentName)) {
-          plateName = value;
-        }
-        else if ("PlateTypeName".equals(currentName)) {
-          plateDescription = value;
-        }
-        else if ("PlateRows".equals(currentName)) {
-          plateRows = Integer.parseInt(value);
-        }
-        else if ("PlateColumns".equals(currentName)) {
-          plateCols = Integer.parseInt(value);
-        }
-        else if ("PlateID".equals(currentName)) {
-          plateID = value;
-        }
-        else if ("MeasurementStartTime".equals(currentName)) {
-          measurementTime = value;
-        }
-      }
-
-      if ("User".equals(currentName)) {
-        displayName = value;
-      }
-      else if (activePlane != null && "Image".equals(parentName)) {
-        if ("URL".equals(currentName)) {
-          if (value.startsWith("http")) {
-            activePlane.filename = value;
-          }
-          else {
-            Location parent =
-              new Location(currentId).getAbsoluteFile().getParentFile();
-            activePlane.filename = new Location(parent, value).getAbsolutePath();
-          }
-        }
-        else if ("Row".equals(currentName)) {
-          activePlane.row = Integer.parseInt(value) - 1;
-        }
-        else if ("Col".equals(currentName)) {
-          activePlane.col = Integer.parseInt(value) - 1;
-        }
-        else if ("FieldID".equals(currentName)) {
-          activePlane.field = Integer.parseInt(value);
-        }
-        else if ("PlaneID".equals(currentName)) {
-          activePlane.z = Integer.parseInt(value);
-        }
-        else if ("ImageSizeX".equals(currentName)) {
-          activePlane.x = Integer.parseInt(value);
-        }
-        else if ("ImageSizeY".equals(currentName)) {
-          activePlane.y = Integer.parseInt(value);
-        }
-        else if ("TimepointID".equals(currentName)) {
-          activePlane.t = Integer.parseInt(value);
-        }
-        else if ("ChannelID".equals(currentName)) {
-          activePlane.c = Integer.parseInt(value);
-        }
-        else if ("ChannelName".equals(currentName)) {
-          activePlane.channelName = value;
-        }
-        else if ("ImageResolutionX".equals(currentName)) {
-          activePlane.setResolutionX(value, currentUnit);
-        }
-        else if ("ImageResolutionY".equals(currentName)) {
-          activePlane.setResolutionY(value, currentUnit);
-        }
-        else if ("PositionX".equals(currentName)) {
-          activePlane.setPositionX(value, currentUnit);
-        }
-        else if ("PositionY".equals(currentName)) {
-          activePlane.setPositionY(value, currentUnit);
-        }
-        else if ("PositionZ".equals(currentName)) {
-          activePlane.setPositionZ(value, currentUnit);
-        }
-        else if ("MeasurementTimeOffset".equals(currentName)) {
-          activePlane.setDeltaT(value, currentUnit);
-        }
-        else if ("ObjectiveMagnification".equals(currentName)) {
-          activePlane.magnification = Double.parseDouble(value);
-        }
-        else if ("ObjectiveNA".equals(currentName)) {
-          activePlane.lensNA = Double.parseDouble(value);
-        }
-        else if ("MainEmissionWavelength".equals(currentName)) {
-          activePlane.setEmWavelength(value, currentUnit);
-        }
-        else if ("MainExcitationWavelength".equals(currentName)) {
-          activePlane.setExWavelength(value, currentUnit);
-        }
-        else if ("AcquisitionType".equals(currentName)) {
-          activePlane.acqType = value;
-        }
-        else if ("ChannelType".equals(currentName)) {
-          activePlane.channelType = value;
-        }
-        else if ("AbsTime".equals(currentName)) {
-          activePlane.acqTime = value;
-        }
-      }
-
-      if (qName.equals("Image") && activePlane != null) {
-        planes.add(activePlane);
-      }
-
-      if (!qName.equals(ROOT_ELEMENT)) {
-        elementNames.remove(elementNames.size() - 1);
-      }
-      currentUnit = null;
-    }
-
   }
 
   @Override


### PR DESCRIPTION
This adds a new `ColumbusReader` class for importing Columbus datasets using a `MeasurementIndex.ColumbusIDX.xml` file.  As with `HarmonyReader`, `ColumbusReader` implements `IHCSReader` to facilitate plate acquisition grouping in OMERO.

This also includes some refactoring of the existing `HarmonyReader`, so that common logic (e.g. parsing `EvaluationInputData` XML) can be reused between the two readers.  I would not expect `HarmonyReader` to exhibit any difference in functionality.
